### PR TITLE
 [FEAT]  get message wise ratings from chat UI

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -138,6 +138,7 @@ function sendConversation(conversation_id, data_short) {
     getFromStorage("rate_" + conversation_id).then((rate) => {
         if (rate !== null) {
             conversation_metadata["rate"] = rate;
+            conversation_metadata["message_ratings"] = data_short.ratings
         }
 
         getFromStorage("user_id").then((user_id_from_storage) => {

--- a/extension/background.js
+++ b/extension/background.js
@@ -84,7 +84,7 @@ function handleLocalDbIds() {
         if (request.type === "update_local_db_ids") {
             let local_db_ids = [];
             getFromStorage("local_db_ids").then((local_db_ids_from_storage) => {
-                if (local_db_ids !== null) {
+                if (local_db_ids_from_storage !== null) {
                     local_db_ids = local_db_ids_from_storage;
                     console.log("local_db_ids loaded from storage", local_db_ids);
                 }
@@ -135,10 +135,12 @@ function sendConversation(conversation_id, data_short) {
     console.log("sending conversation to server...")
 
     let conversation_metadata = {}
+    if ("ratings" in data_short) {
+        conversation_metadata["message_ratings"] = data_short.ratings;
+    }
     getFromStorage("rate_" + conversation_id).then((rate) => {
         if (rate !== null) {
             conversation_metadata["rate"] = rate;
-            conversation_metadata["message_ratings"] = data_short.ratings
         }
 
         getFromStorage("user_id").then((user_id_from_storage) => {

--- a/extension/index_frame.js
+++ b/extension/index_frame.js
@@ -519,17 +519,12 @@ function init() {
     }
 
     // Check if the ratings have changed
-    if (cur_ratings.length < new_ratings.length) {
+    if (cur_ratings.length !== new_ratings.length) {
       need_update = true;
-      new_conversation = true;
-    } else if (cur_ratings.length > new_ratings.length) {
-      new_conversation = false;
-      need_update = false;
     } else {
       for (let i = 0; i < cur_ratings.length; i++) {
         if (cur_ratings[i] !== new_ratings[i]) {
           need_update = true;
-          new_conversation = true;
           break;
         }
       }
@@ -638,32 +633,35 @@ function init() {
 
 
 function queryAndUpdateRating(n_messages) {
-  const parent_selector = ".absolute.bottom-1.right-0.-mb-4.flex.max-md\\:transition-all.md\\:bottom-0.md\\:group-hover\\:visible.md\\:group-hover\\:opacity-100";
+  const parent_selector = 'div.absolute.bottom-1.right-0';
   const positive_selector = "[title=\"Remove +1\"]";
   const negative_selector = "[title=\"Remove -1\"]";
-  const new_ratings = [];
+  const new_ratings = Array(n_messages).fill(0);
 
   // find all rating elements :+1: and :-1: and store the ratings
   return waitForElms(parent_selector).then((parents) => {
-    for (let i = 0; i < n_messages; i++) {
-
+    if (!parents || parents.length === 0) {
+        console.log("No ratings found"); // Note - we currently don't support ratings in Gradio UI
+        return new_ratings;
+    }
+    for (let i = 0; i < parents.length; i++) {
       const positive_child = parents[i].querySelector(positive_selector);
       const negative_child = parents[i].querySelector(negative_selector);
       
       if (positive_child) {
         console.log("positive rating found");
-        new_ratings.push(1);
+        new_ratings[i] = 1;
       } else if (negative_child) {
         console.log("negative rating found");
-        new_ratings.push(-1);
+        new_ratings[i] = -1;
       } else {
-        new_ratings.push(0);
+        new_ratings[i] = 0;
       }
     }
     return new_ratings;
   }).catch((err) => {
     console.error("Error in queryAndUpdateRating:", err);
-    return Array(n_messages).fill(0);
+    return new_ratings;
   });
 }
 

--- a/scripts/demo_server.py
+++ b/scripts/demo_server.py
@@ -1,0 +1,87 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from sqlalchemy import create_engine, Column, Integer, String, ARRAY, JSON, inspect
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+from anonymization import Anonymization, AnonymizerChain, EmailAnonymizer, PhoneNumberAnonymizer, MacAddressAnonymizer, \
+    Ipv4Anonymizer, Ipv6Anonymizer, CreditCardAnonymizer, IbanAnonymizer
+
+
+app = Flask(__name__)
+CORS(app, resources={r"/api/*": {"origins": "*"}})
+
+# Define your SQLAlchemy database connection
+DATABASE_URL = 'INSERT_YOUR_DATABASE_URL_HERE'
+engine = create_engine(DATABASE_URL)
+
+# Create a Session
+Session = sessionmaker(bind=engine)
+session = Session()
+
+# Define your SQLAlchemy model
+Base = declarative_base()
+
+
+class Conversation(Base):
+    __tablename__ = 'conversations'
+
+    id = Column(Integer, primary_key=True)
+    conversation_id = Column(String(255), nullable=False)
+    bot_msgs = Column(ARRAY(String), nullable=False)
+    user_msgs = Column(ARRAY(String), nullable=False)
+    page_url = Column(String(255), nullable=False)
+    user_id = Column(String(255), nullable=False)
+    user_metadata = Column(JSON, nullable=True)
+    timestamp = Column(String(255), nullable=False)
+    conversation_metadata = Column(JSON, nullable=True)
+
+
+# Create the table if it doesn't exist
+if not inspect(engine).has_table('conversations'):
+    Base.metadata.create_all(engine)
+
+anon = AnonymizerChain(Anonymization('en_US'))
+anon.add_anonymizers(EmailAnonymizer, PhoneNumberAnonymizer, MacAddressAnonymizer, \
+    Ipv4Anonymizer, Ipv6Anonymizer, CreditCardAnonymizer, IbanAnonymizer)
+
+
+@app.route('/api/endpoint', methods=['POST'])
+def store_conversation():
+    try:
+        data = request.get_json()
+
+        # Extract data from the request
+        conversation_id = data['conversation_id']
+        bot_msgs = data['bot_msgs']
+        user_msgs = data['user_msgs']
+        page_url = data['page_url']
+        user_id = data['user_id']
+        user_metadata = data['user_metadata']
+        timestamp = data['timestamp']
+        conversation_metadata = data['conversation_metadata']
+
+        anon_bot_msgs = [anon.anonymize(msg) for msg in bot_msgs]
+        anon_user_msgs = [anon.anonymize(msg) for msg in user_msgs]
+
+        # Create a new Conversation record and add it to the database
+        new_conversation = Conversation(
+            conversation_id=conversation_id,
+            bot_msgs=anon_bot_msgs,
+            user_msgs=anon_user_msgs,
+            page_url=page_url,
+            user_id=user_id,
+            user_metadata=user_metadata,
+            timestamp=timestamp,
+            conversation_metadata=conversation_metadata
+        )
+        session.add(new_conversation)
+        session.commit()
+
+        return jsonify({'message': 'Conversation saved successfully', "conversation_id": conversation_id}), 200
+    except Exception as e:
+        print(e)
+        return jsonify({'error': str(e)}), 500
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
This is a work in progress to implement a feature to extract ratings from chat UI conversations.

So far the PR implement a function to query the button elements (:+1:  and :-1: ) from the UI and add these as integers to the `conversation_metadata` of the `data_short` packet sent to the server. The ratings are represented as -1, 0, and 1.

The PR also migrates `demo_server.py` which can be used for local emulation of the heroku server.