### PR TITLE
Add copilot support

### DIFF
--- a/Supported_models_and_websites.txt
+++ b/Supported_models_and_websites.txt
@@ -1,6 +1,7 @@
 Claude
 HuggingFace through Gradio UI (HuggingFace Chat UI)
 ChatGPT
+Copilot
 Gemini
 MistralAI Le Chat
 Poe

--- a/extension/index_frame.js
+++ b/extension/index_frame.js
@@ -26,6 +26,7 @@ function init() {
   let gemini_app;
   let mistral_app;
   let poe_app;
+  let copilot_app;
   let app;
   let init_already = false;
 
@@ -220,6 +221,38 @@ function init() {
         }
         setInterval(queryAndUpdateConversationsGemini, 7000);
         setInterval(addBadge, 5000);
+      });
+    }
+
+    if (window.location.href.includes("copilot.microsoft.com")) {
+      // Let's find the copilot-app element
+      waitForElm("cib-serp-main").then((copilot_app_from_storage) => {
+        copilot_app = copilot_app_from_storage;
+
+        if (!copilot_app) {
+          console.log("Couldn't find copilot-app.")
+        } else {
+          shouldShare = true;
+          app = copilot_app;
+          console.log("copilot-app found!", copilot_app);
+        }
+
+        if (!init_already || copilot_app) {
+          init_already = true;
+          getUserInfoFromStorage();
+          handleDataUpdatesFromPopup();
+        }
+
+        if (copilot_app) {
+          if (!age_verified) {
+            console.log("age not verified - adding need verification badge");
+            addNeedVerificationBadge();
+          } else {
+            addBadge();
+            setInterval(addBadge, 5000);
+          }
+          setInterval(queryAndUpdateConversationsCopilot, 7000);
+        }
       });
     }
 
@@ -931,6 +964,13 @@ function init() {
         ".Prose_presets_theme-on-accent__rESxX",
         ".Prose_presets_theme-hi-contrast__LQyM9"
 
+    );
+  }
+
+  function queryAndUpdateConversationsCopilot() {
+    queryAndUpdateConversations(
+        "cib-message-group.user .ac-text-block",
+        "cib-message-group:not(.user) .ac-text-block"
     );
   }
 

--- a/extension/index_frame.js
+++ b/extension/index_frame.js
@@ -225,35 +225,36 @@ function init() {
     }
 
     if (window.location.href.includes("copilot.microsoft.com")) {
-      // Let's find the copilot-app element
-      waitForElm("cib-serp-main").then((copilot_app_from_storage) => {
-        copilot_app = copilot_app_from_storage;
+      console.log("Copilot website detected. Starting to look for #app element...");
+      const intervalId = setInterval(() => {
+        const copilot_app_from_dom = document.querySelector("#app");
+        if (copilot_app_from_dom) {
+          console.log("#app element found!");
+          clearInterval(intervalId); // Stop checking once found
 
-        if (!copilot_app) {
-          console.log("Couldn't find copilot-app.")
-        } else {
-          shouldShare = true;
+          copilot_app = copilot_app_from_dom;
           app = copilot_app;
-          console.log("copilot-app found!", copilot_app);
-        }
+          shouldShare = true;
 
-        if (!init_already || copilot_app) {
-          init_already = true;
-          getUserInfoFromStorage();
-          handleDataUpdatesFromPopup();
-        }
-
-        if (copilot_app) {
-          if (!age_verified) {
-            console.log("age not verified - adding need verification badge");
-            addNeedVerificationBadge();
-          } else {
-            addBadge();
-            setInterval(addBadge, 5000);
+          if (!init_already) {
+            init_already = true;
+            getUserInfoFromStorage();
+            handleDataUpdatesFromPopup();
           }
-          setInterval(queryAndUpdateConversationsCopilot, 7000);
+
+          getFromStorage("age_verified").then((age_verified_from_storage) => {
+            age_verified = age_verified_from_storage ?? false;
+            if (!age_verified) {
+              console.log("age not verified - adding need verification badge");
+              addNeedVerificationBadge();
+            } else {
+              addBadge();
+              setInterval(addBadge, 5000);
+            }
+            setInterval(queryAndUpdateConversationsCopilot, 7000);
+          });
         }
-      });
+      }, 1000); // Check every second
     }
 
     if (window.location.href.includes("chat.mistral.ai")) {
@@ -969,8 +970,8 @@ function init() {
 
   function queryAndUpdateConversationsCopilot() {
     queryAndUpdateConversations(
-        "cib-message-group.user .ac-text-block",
-        "cib-message-group:not(.user) .ac-text-block"
+        '[data-content="user-message"]',
+        '[data-content="ai-message"] p'
     );
   }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -34,6 +34,17 @@
   "host_permissions": ["https://huggingface.co/spaces/*", "https://*/hf.space/*", "https://grok.com/*", "https://copilot.microsoft.com/*"],
   "permissions": [
     "storage",
-    "activeTab"
-  ]
+    "activeTab",
+    "declarativeNetRequest",
+    "declarativeNetRequestWithHostAccess"
+  ],
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "ruleset_1",
+        "enabled": true,
+        "path": "rules.json"
+      }
+    ]
+  }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -31,7 +31,7 @@
   "background": {
     "service_worker": "background.js"
   },
-  "host_permissions": ["https://huggingface.co/spaces/*", "https://*/hf.space/*", "https://grok.com/*", "https://copilot.microsoft.com/*"],
+  "host_permissions": ["https://huggingface.co/spaces/*", "https://*/hf.space/*", "https://grok.com/*"],
   "permissions": [
     "storage",
     "activeTab",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -31,7 +31,7 @@
   "background": {
     "service_worker": "background.js"
   },
-  "host_permissions": ["https://huggingface.co/spaces/*", "https://*/hf.space/*", "https://grok.com/*"],
+  "host_permissions": ["https://huggingface.co/spaces/*", "https://*/hf.space/*", "https://grok.com/*", "https://copilot.microsoft.com/*"],
   "permissions": [
     "storage",
     "activeTab"

--- a/extension/rules.json
+++ b/extension/rules.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "csp_remove_rule",
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "responseHeaders": [
+        {
+          "header": "Content-Security-Policy",
+          "operation": "remove"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "||copilot.microsoft.com",
+      "resourceTypes": ["main_frame", "sub_frame"]
+    }
+  }
+]


### PR DESCRIPTION
Resolves #8 

This improvement was not straightforward but required editing the manifest and adding a new rules.json file to be able to overrule the "Content-Security-Policy" used on the copilot.microsoft.com and make the ShareLM plugin able to access the contents of the page, detect and collect the conversations from it.