### PR TITLE
[DRAFT] review controls

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,606 +1,502 @@
+// background.js
 const API_URL = "https://share-lm-4e25a5769ac0.herokuapp.com/api/endpoint";
 
 const DEFAULT_PRIVACY_SETTINGS = {
-  require_manual_review: true,
-  enable_redaction: true,
-  unlink_shared_ids: true,
-  regex_rules_text: [
-    String.raw`\b(?:\d{1,3}\.){3}\d{1,3}\b => [REDACTED_IP]`,
-    String.raw`[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,} => [REDACTED_EMAIL]`,
-    String.raw`\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b => [REDACTED_MAC]`,
-    String.raw`\b[0-9A-Fa-f]{8}-(?:[0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}\b => [REDACTED_UUID]`,
-    String.raw`(?:(?:[A-Za-z]:)?(?:\\|/)[^\s"']+) => [REDACTED_PATH]`,
-  ].join('\n'),
+    require_manual_review: true,
+    enable_redaction: true,
+    unlink_shared_ids: true,
+    regex_rules_text: [
+        String.raw`\b(?:\d{1,3}\.){3}\d{1,3}\b => [REDACTED_IP]`,
+        String.raw`[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,} => [REDACTED_EMAIL]`,
+        String.raw`\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b => [REDACTED_MAC]`,
+        String.raw`\b[0-9A-Fa-f]{8}-(?:[0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}\b => [REDACTED_UUID]`,
+        String.raw`(?:(?:[A-Za-z]:)?(?:\\|/)[^\s"']+) => [REDACTED_PATH]`,
+    ].join("\n"),
 };
 
 const requestQueue = [];
 let isProcessing = false;
 
+function enqueueStorageUpdate(updateFunction) {
+    return new Promise((resolve, reject) => {
+        requestQueue.push({ updateFunction, resolve, reject });
+        processQueue();
+    });
+}
+
+function processQueue() {
+    if (isProcessing || requestQueue.length === 0) return;
+
+    isProcessing = true;
+    const { updateFunction, resolve, reject } = requestQueue.shift();
+
+    Promise.resolve()
+        .then(updateFunction)
+        .then((result) => {
+            resolve(result);
+            isProcessing = false;
+            processQueue();
+        })
+        .catch((error) => {
+            reject(error);
+            isProcessing = false;
+            processQueue();
+        });
+}
+
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
-  if (changeInfo.status === 'complete') {
-    handleIconStatus(tabId);
-    updateSharingStatus(tabId);
-  }
+    if (changeInfo.status === 'complete') {
+        handleIconStatus(tabId);
+        updateSharingStatus(tabId);
+    }
 });
 
 chrome.tabs.onActivated.addListener((activeInfo) => {
-  handleIconStatus(activeInfo.tabId);
-  updateSharingStatus(activeInfo.tabId);
+    handleIconStatus(activeInfo.tabId);
+    updateSharingStatus(activeInfo.tabId);
 });
 
 const MinInMillis = 60 * 1000;
 setInterval(() => {
-  removeInvalidAndPostToDb(true).catch((error) => {
-    console.error('Scheduled publish failed', error);
-  });
+    removeInvalidAndPostToDb(true).catch((error) => {
+        console.error('Scheduled publish failed', error);
+    });
 }, 5 * MinInMillis);
 
 handleRuntimeMessages();
 
-function enqueueStorageUpdate(updateFunction) {
-  return new Promise((resolve, reject) => {
-    requestQueue.push({ updateFunction, resolve, reject });
-    processQueue();
-  });
-}
-
-function processQueue() {
-  if (isProcessing || requestQueue.length === 0) {
-    return;
-  }
-
-  isProcessing = true;
-  const { updateFunction, resolve, reject } = requestQueue.shift();
-
-  Promise.resolve()
-    .then(updateFunction)
-    .then((result) => {
-      resolve(result);
-      isProcessing = false;
-      processQueue();
-    })
-    .catch((error) => {
-      reject(error);
-      isProcessing = false;
-      processQueue();
-    });
-}
-
 function handleRuntimeMessages() {
-  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.type === 'update_local_db_ids') {
-      enqueueStorageUpdate(async () => {
-        if (!request.id_to_add || !request.conversation) {
-          return { ok: false, error: 'missing conversation payload' };
+    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+        if (request.type === "update_local_db_ids") {
+            enqueueStorageUpdate(async () => {
+                if (!request.id_to_add || !request.conversation) {
+                    return { ok: false, error: "missing conversation payload" };
+                }
+
+                let local_db_ids = (await getFromStorage("local_db_ids")) || [];
+                const existingConversation = await getFromStorage(request.id_to_add);
+                const storedConversation = await buildStoredConversation(
+                    request.id_to_add,
+                    request.conversation,
+                    existingConversation
+                );
+
+                if (!local_db_ids.includes(request.id_to_add)) {
+                    local_db_ids = [...local_db_ids, request.id_to_add];
+                    await saveToStorage("local_db_ids", local_db_ids);
+                }
+
+                await saveToStorage(request.id_to_add, storedConversation);
+                return { ok: true, conversation_id: request.id_to_add, conversation: storedConversation };
+            }).then(sendResponse).catch((error) => {
+                console.error("Failed to update local archive", error);
+                sendResponse({ ok: false, error: String(error) });
+            });
+            return true;
+        } else if (request.type === "publish") {
+            removeInvalidAndPostToDb(false).then(sendResponse).catch((error) => {
+                console.error("Manual publish failed", error);
+                sendResponse({ ok: false, error: String(error) });
+            });
+            return true;
+        } else if (request.type === "update_conversation_privacy") {
+            enqueueStorageUpdate(async () => {
+                const conversation = await getFromStorage(request.conversation_id);
+                if (!conversation) {
+                    return { ok: false, error: "conversation not found" };
+                }
+                if (conversation.published_at) {
+                    conversation.publish_state = "shared";
+                } else if (request.publish_state) {
+                    conversation.publish_state = request.publish_state;
+                }
+                conversation.updated_at = new Date().toISOString();
+                await saveToStorage(request.conversation_id, conversation);
+                return { ok: true, conversation };
+            }).then(sendResponse).catch((error) => {
+                sendResponse({ ok: false, error: String(error) });
+            });
+            return true;
+        } else if (request.type === "get_privacy_settings") {
+            getPrivacySettings().then((privacy_settings) => sendResponse({ ok: true, privacy_settings })).catch((error) => {
+                sendResponse({ ok: false, error: String(error) });
+            });
+            return true;
+        } else if (request.type === "save_privacy_settings") {
+            const normalized = normalizePrivacySettings(request.privacy_settings || {});
+            saveToStorage("privacy_settings", normalized).then(() => {
+                sendResponse({ ok: true, privacy_settings: normalized });
+            }).catch((error) => {
+                sendResponse({ ok: false, error: String(error) });
+            });
+            return true;
         }
-
-        let localDbIds = (await getFromStorage('local_db_ids')) || [];
-        const existingConversation = await getFromStorage(request.id_to_add);
-        const storedConversation = await buildStoredConversation(
-          request.id_to_add,
-          request.conversation,
-          existingConversation
-        );
-
-        if (!localDbIds.includes(request.id_to_add)) {
-          localDbIds = [...localDbIds, request.id_to_add];
-          await saveToStorage('local_db_ids', localDbIds);
-        }
-
-        await saveToStorage(request.id_to_add, storedConversation);
-
-        return {
-          ok: true,
-          request_type: 'add',
-          conversation_id: request.id_to_add,
-          conversation: storedConversation,
-        };
-      })
-        .then(sendResponse)
-        .catch((error) => {
-          console.error('Failed to update local archive', error);
-          sendResponse({ ok: false, error: String(error) });
-        });
-      return true;
-    }
-
-    if (request.type === 'publish') {
-      removeInvalidAndPostToDb(false)
-        .then(sendResponse)
-        .catch((error) => {
-          console.error('Manual publish failed', error);
-          sendResponse({ ok: false, error: String(error) });
-        });
-      return true;
-    }
-
-    if (request.type === 'update_conversation_privacy') {
-      enqueueStorageUpdate(async () => {
-        const conversation = await getFromStorage(request.conversation_id);
-        if (!conversation) {
-          return { ok: false, error: 'conversation not found' };
-        }
-
-        if (conversation.published_at) {
-          conversation.publish_state = 'shared';
-        } else if (request.publish_state) {
-          conversation.publish_state = request.publish_state;
-        }
-
-        conversation.updated_at = new Date().toISOString();
-        await saveToStorage(request.conversation_id, conversation);
-
-        return { ok: true, conversation };
-      })
-        .then(sendResponse)
-        .catch((error) => {
-          console.error('Failed to update conversation privacy', error);
-          sendResponse({ ok: false, error: String(error) });
-        });
-      return true;
-    }
-
-    if (request.type === 'get_privacy_settings') {
-      getPrivacySettings()
-        .then((privacySettings) => sendResponse({ ok: true, privacy_settings: privacySettings }))
-        .catch((error) => sendResponse({ ok: false, error: String(error) }));
-      return true;
-    }
-
-    if (request.type === 'save_privacy_settings') {
-      const normalized = normalizePrivacySettings(request.privacy_settings || {});
-      saveToStorage('privacy_settings', normalized)
-        .then(() => sendResponse({ ok: true, privacy_settings: normalized }))
-        .catch((error) => sendResponse({ ok: false, error: String(error) }));
-      return true;
-    }
-
-    return false;
-  });
-}
-
-async function buildStoredConversation(conversationId, incomingConversation, existingConversation) {
-  const privacySettings = await getPrivacySettings();
-  const shouldShareState = await getFromStorage('shouldShare');
-  const shouldShare = shouldShareState === null ? true : Boolean(shouldShareState.shouldShare);
-  const now = new Date().toISOString();
-
-  let publishState;
-  if (existingConversation && existingConversation.published_at) {
-    publishState = 'shared';
-  } else if (existingConversation && existingConversation.publish_state) {
-    publishState = existingConversation.publish_state;
-  } else if (!shouldShare) {
-    publishState = 'blocked';
-  } else {
-    publishState = privacySettings.require_manual_review ? 'needs_review' : 'approved';
-  }
-
-  return {
-    ...incomingConversation,
-    created_at: existingConversation?.created_at || incomingConversation.timestamp || now,
-    updated_at: now,
-    publish_state: publishState,
-    published_at: existingConversation?.published_at || null,
-    shared_user_id: existingConversation?.shared_user_id || null,
-  };
-}
-
-async function removeInvalidAndPostToDb(checkInterval = true) {
-  const currentTime = new Date();
-  const localDbIds = (await getFromStorage('local_db_ids')) || [];
-  let publishedCount = 0;
-  let skippedCount = 0;
-
-  for (const conversationId of [...localDbIds]) {
-    const conversation = await getFromStorage(conversationId);
-
-    if (!conversation) {
-      const nextIds = localDbIds.filter((item) => item !== conversationId);
-      await saveToStorage('local_db_ids', nextIds);
-      continue;
-    }
-
-    if (conversation.published_at) {
-      skippedCount += 1;
-      continue;
-    }
-
-    const publishState = conversation.publish_state || 'approved';
-    if (publishState !== 'approved') {
-      skippedCount += 1;
-      continue;
-    }
-
-    if (checkInterval && !isTimestampOlderThanXHours(conversation.timestamp, currentTime, 24)) {
-      skippedCount += 1;
-      continue;
-    }
-
-    const success = await sendConversation(conversationId, conversation);
-    if (success) {
-      conversation.published_at = new Date().toISOString();
-      conversation.publish_state = 'shared';
-      conversation.updated_at = conversation.published_at;
-      await saveToStorage(conversationId, conversation);
-      publishedCount += 1;
-    }
-  }
-
-  return {
-    ok: true,
-    published_count: publishedCount,
-    skipped_count: skippedCount,
-    total_local_conversations: localDbIds.length,
-  };
-}
-
-async function sendConversation(conversationId, conversation) {
-  try {
-    const payload = await buildPublishPayload(conversationId, conversation);
-    const response = await fetch(API_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
+        return false;
     });
-
-    if (!response.ok) {
-      throw new Error(`Network response was not ok (${response.status})`);
-    }
-
-    await response.json();
-    const messageCount = Array.isArray(payload.user_msgs) ? payload.user_msgs.length : 0;
-    await safeIncrementMessagesCounter(messageCount);
-    return true;
-  } catch (error) {
-    console.error('Error sending conversation:', error);
-    return false;
-  }
 }
 
-async function buildPublishPayload(conversationId, conversation) {
-  const privacySettings = await getPrivacySettings();
-  let userId = await getFromStorage('user_id');
-  if (userId === null) {
-    userId = uuidv4();
-    await saveToStorage('user_id', userId);
-  }
+async function buildStoredConversation(conversation_id, incomingConversation, existingConversation) {
+    const privacySettings = await getPrivacySettings();
+    const now = new Date().toISOString();
+    let publish_state;
 
-  const userMetadata = (await getFromStorage('user_metadata')) || {};
-  const conversationMetadata = {};
-
-  if ('ratings' in conversation) {
-    conversationMetadata.message_ratings = conversation.ratings;
-  }
-
-  const rate = await getFromStorage(`rate_${conversationId}`);
-  if (rate !== null) {
-    conversationMetadata.rate = rate;
-  }
-
-  const sanitizedConversation = privacySettings.enable_redaction
-    ? applyRedactionsToConversation(conversation, privacySettings.regex_rules_text)
-    : { conversation: deepClone(conversation), summary: { total_matches: 0, matches_by_rule: [] } };
-
-  if (privacySettings.enable_redaction) {
-    conversationMetadata.redaction_summary = sanitizedConversation.summary;
-  }
-
-  let sharedUserId = userId;
-  if (privacySettings.unlink_shared_ids) {
-    sharedUserId = conversation.shared_user_id || uuidv4();
-    if (sharedUserId !== conversation.shared_user_id) {
-      conversation.shared_user_id = sharedUserId;
-      await saveToStorage(conversationId, conversation);
+    if (existingConversation && existingConversation.published_at) {
+        publish_state = "shared";
+    } else if (existingConversation && existingConversation.publish_state) {
+        publish_state = existingConversation.publish_state;
+    } else {
+        publish_state = privacySettings.require_manual_review ? "needs_review" : "approved";
     }
-    conversationMetadata.shared_user_id_mode = 'per_conversation';
-  } else {
-    conversationMetadata.shared_user_id_mode = 'stable';
-  }
 
-  return {
-    conversation_id: conversationId,
-    bot_msgs: sanitizedConversation.conversation.bot_msgs || [],
-    user_msgs: sanitizedConversation.conversation.user_msgs || [],
-    page_url: sanitizePageUrl(sanitizedConversation.conversation.page_url),
-    user_id: sharedUserId,
-    user_metadata: {
-      ...userMetadata,
-      sharelm_privacy_mode: describePrivacyMode(privacySettings),
-    },
-    timestamp: sanitizedConversation.conversation.timestamp,
-    conversation_metadata: conversationMetadata,
-  };
+    return {
+        ...incomingConversation,
+        created_at: (existingConversation && existingConversation.created_at) || incomingConversation.timestamp || now,
+        updated_at: now,
+        publish_state,
+        published_at: (existingConversation && existingConversation.published_at) || null,
+        shared_user_id: (existingConversation && existingConversation.shared_user_id) || null,
+    };
+}
+
+async function sendConversation(conversation_id, conversation) {
+    try {
+        const data = await buildPublishPayload(conversation_id, conversation);
+        const response = await fetch(API_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+        });
+        if (!response.ok) {
+            throw new Error("Network response was not ok");
+        }
+        await response.json();
+        await safeIncrementMessagesCounter((data.user_msgs || []).length);
+        return true;
+    } catch (error) {
+        console.error("Error:", error);
+        return false;
+    }
+}
+
+async function buildPublishPayload(conversation_id, conversation) {
+    const privacySettings = await getPrivacySettings();
+    let conversation_metadata = {};
+    if ("ratings" in conversation) {
+        conversation_metadata["message_ratings"] = conversation.ratings;
+    }
+    const rate = await getFromStorage("rate_" + conversation_id);
+    if (rate !== null) {
+        conversation_metadata["rate"] = rate;
+    }
+
+    let user_id = await getFromStorage("user_id");
+    if (user_id === null) {
+        user_id = uuidv4();
+        await saveToStorage("user_id", user_id);
+    }
+    let user_metadata = (await getFromStorage("user_metadata")) ?? {};
+
+    const sanitizedConversation = privacySettings.enable_redaction
+        ? applyRedactionsToConversation(conversation, privacySettings.regex_rules_text)
+        : { conversation: deepClone(conversation), summary: { total_matches: 0, matches_by_rule: [] } };
+
+    if (privacySettings.enable_redaction) {
+        conversation_metadata["redaction_summary"] = sanitizedConversation.summary;
+    }
+
+    let shared_user_id = user_id;
+    if (privacySettings.unlink_shared_ids) {
+        shared_user_id = conversation.shared_user_id || uuidv4();
+        if (shared_user_id !== conversation.shared_user_id) {
+            conversation.shared_user_id = shared_user_id;
+            await saveToStorage(conversation_id, conversation);
+        }
+        conversation_metadata["shared_user_id_mode"] = "per_conversation";
+    } else {
+        conversation_metadata["shared_user_id_mode"] = "stable";
+    }
+
+    return {
+        conversation_id,
+        bot_msgs: sanitizedConversation.conversation.bot_msgs || [],
+        user_msgs: sanitizedConversation.conversation.user_msgs || [],
+        page_url: sanitizePageUrl(sanitizedConversation.conversation.page_url),
+        user_id: shared_user_id,
+        user_metadata: {
+            ...user_metadata,
+            sharelm_privacy_mode: describePrivacyMode(privacySettings),
+        },
+        timestamp: sanitizedConversation.conversation.timestamp,
+        conversation_metadata,
+    };
 }
 
 function describePrivacyMode(privacySettings) {
-  if (
-    privacySettings.require_manual_review ||
-    privacySettings.enable_redaction ||
-    privacySettings.unlink_shared_ids
-  ) {
-    return 'advanced';
-  }
-  return 'standard';
+    return (privacySettings.require_manual_review || privacySettings.enable_redaction || privacySettings.unlink_shared_ids)
+        ? "advanced"
+        : "standard";
+}
+
+async function removeInvalidAndPostToDb(checkInterval = true) {
+    console.log("removeInvalidAndPostToDb()");
+    const currentTime = new Date();
+    const local_db_ids = (await getFromStorage("local_db_ids")) || [];
+    let published_count = 0;
+    let skipped_count = 0;
+
+    for (const conversationId of [...local_db_ids]) {
+        const conversation = await getFromStorage(conversationId);
+        if (conversation === null) {
+            const nextIds = local_db_ids.filter((item) => item !== conversationId);
+            await saveToStorage("local_db_ids", nextIds);
+            continue;
+        }
+        if (conversation.published_at) {
+            skipped_count += 1;
+            continue;
+        }
+        const publish_state = conversation.publish_state || "approved";
+        if (publish_state !== "approved") {
+            skipped_count += 1;
+            continue;
+        }
+        if (checkInterval && !isTimestampOlderThanXHours(conversation.timestamp, currentTime, 24)) {
+            skipped_count += 1;
+            continue;
+        }
+        const success = await sendConversation(conversationId, conversation);
+        if (success) {
+            conversation.published_at = new Date().toISOString();
+            conversation.publish_state = "shared";
+            conversation.updated_at = conversation.published_at;
+            await saveToStorage(conversationId, conversation);
+            published_count += 1;
+        }
+    }
+
+    return { ok: true, published_count, skipped_count, total_local_conversations: local_db_ids.length };
 }
 
 function applyRedactionsToConversation(conversation, rulesText) {
-  const clonedConversation = deepClone(conversation);
-  const rules = parseRedactionRules(rulesText);
-  const summary = {
-    total_matches: 0,
-    matches_by_rule: [],
-  };
+    const clonedConversation = deepClone(conversation);
+    const rules = parseRedactionRules(rulesText);
+    const summary = { total_matches: 0, matches_by_rule: [] };
 
-  const applyToValue = (value) => {
-    if (typeof value !== 'string') {
-      return value;
+    const applyToValue = (value) => {
+        if (typeof value !== "string") {
+            return value;
+        }
+        const result = redactString(value, rules);
+        summary.total_matches += result.totalMatches;
+        result.matchesByRule.forEach((item) => {
+            const existing = summary.matches_by_rule.find((entry) => entry.name === item.name);
+            if (existing) {
+                existing.count += item.count;
+            } else {
+                summary.matches_by_rule.push({ name: item.name, count: item.count });
+            }
+        });
+        return result.value;
+    };
+
+    clonedConversation.user_msgs = (clonedConversation.user_msgs || []).map(applyToValue);
+    clonedConversation.bot_msgs = (clonedConversation.bot_msgs || []).map(applyToValue);
+    clonedConversation.page_url = applyToValue(clonedConversation.page_url || "");
+
+    if (Array.isArray(clonedConversation.canvas_snapshots)) {
+        clonedConversation.canvas_snapshots = clonedConversation.canvas_snapshots.map((snapshot) => ({
+            ...snapshot,
+            data: snapshot.data ? {
+                ...snapshot.data,
+                textContent: applyToValue(snapshot.data.textContent || ""),
+                htmlContent: applyToValue(snapshot.data.htmlContent || ""),
+                displayTitle: applyToValue(snapshot.data.displayTitle || ""),
+            } : snapshot.data,
+        }));
     }
-    const result = redactString(value, rules);
-    summary.total_matches += result.totalMatches;
-    result.matchesByRule.forEach((item) => {
-      const existing = summary.matches_by_rule.find((entry) => entry.name === item.name);
-      if (existing) {
-        existing.count += item.count;
-      } else {
-        summary.matches_by_rule.push({ name: item.name, count: item.count });
-      }
-    });
-    return result.value;
-  };
 
-  clonedConversation.user_msgs = (clonedConversation.user_msgs || []).map(applyToValue);
-  clonedConversation.bot_msgs = (clonedConversation.bot_msgs || []).map(applyToValue);
-  clonedConversation.page_url = applyToValue(clonedConversation.page_url || '');
+    if (Array.isArray(clonedConversation.conversation_timeline)) {
+        clonedConversation.conversation_timeline = clonedConversation.conversation_timeline.map((item) => {
+            if (typeof item.content === "string") {
+                return { ...item, content: applyToValue(item.content) };
+            }
+            if (item.content && typeof item.content === "object") {
+                return {
+                    ...item,
+                    content: {
+                        ...item.content,
+                        title: applyToValue(item.content.title || ""),
+                        textContent: applyToValue(item.content.textContent || ""),
+                        trigger: item.content.trigger,
+                    },
+                };
+            }
+            return item;
+        });
+    }
 
-  if (Array.isArray(clonedConversation.canvas_snapshots)) {
-    clonedConversation.canvas_snapshots = clonedConversation.canvas_snapshots.map((snapshot) => ({
-      ...snapshot,
-      data: snapshot.data
-        ? {
-            ...snapshot.data,
-            textContent: applyToValue(snapshot.data.textContent || ''),
-            htmlContent: applyToValue(snapshot.data.htmlContent || ''),
-            displayTitle: applyToValue(snapshot.data.displayTitle || ''),
-          }
-        : snapshot.data,
-    }));
-  }
-
-  if (Array.isArray(clonedConversation.conversation_timeline)) {
-    clonedConversation.conversation_timeline = clonedConversation.conversation_timeline.map((item) => {
-      if (typeof item.content === 'string') {
-        return { ...item, content: applyToValue(item.content) };
-      }
-
-      if (item.content && typeof item.content === 'object') {
-        return {
-          ...item,
-          content: {
-            ...item.content,
-            title: applyToValue(item.content.title || ''),
-            textContent: applyToValue(item.content.textContent || ''),
-            trigger: item.content.trigger,
-          },
-        };
-      }
-
-      return item;
-    });
-  }
-
-  return { conversation: clonedConversation, summary };
+    return { conversation: clonedConversation, summary };
 }
 
 function parseRedactionRules(rulesText) {
-  const lines = (rulesText || '')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-
-  return lines
-    .map((line, index) => {
-      const separatorIndex = line.indexOf('=>');
-      if (separatorIndex === -1) {
-        return null;
-      }
-
-      const patternText = line.slice(0, separatorIndex).trim();
-      const replacement = line.slice(separatorIndex + 2).trim();
-
-      try {
-        return {
-          name: `rule_${index + 1}`,
-          regex: new RegExp(patternText, 'g'),
-          replacement,
-        };
-      } catch (error) {
-        console.warn('Skipping invalid redaction rule', line, error);
-        return null;
-      }
-    })
-    .filter(Boolean);
+    const lines = (rulesText || "").split("\n").map((line) => line.trim()).filter((line) => line && !line.startsWith("#"));
+    return lines.map((line, index) => {
+        const separatorIndex = line.indexOf("=>");
+        if (separatorIndex === -1) {
+            return null;
+        }
+        const patternText = line.slice(0, separatorIndex).trim();
+        const replacement = line.slice(separatorIndex + 2).trim();
+        try {
+            return { name: `rule_${index + 1}`, regex: new RegExp(patternText, "g"), replacement };
+        } catch (error) {
+            console.warn("Skipping invalid redaction rule", line, error);
+            return null;
+        }
+    }).filter(Boolean);
 }
 
 function redactString(value, rules) {
-  let nextValue = value;
-  let totalMatches = 0;
-  const matchesByRule = [];
-
-  for (const rule of rules) {
-    const matches = nextValue.match(rule.regex);
-    if (!matches || matches.length === 0) {
-      continue;
+    let nextValue = value;
+    let totalMatches = 0;
+    const matchesByRule = [];
+    for (const rule of rules) {
+        const matches = nextValue.match(rule.regex);
+        if (!matches || matches.length === 0) continue;
+        totalMatches += matches.length;
+        matchesByRule.push({ name: rule.name, count: matches.length });
+        nextValue = nextValue.replace(rule.regex, rule.replacement);
     }
-
-    totalMatches += matches.length;
-    matchesByRule.push({ name: rule.name, count: matches.length });
-    nextValue = nextValue.replace(rule.regex, rule.replacement);
-  }
-
-  return { value: nextValue, totalMatches, matchesByRule };
+    return { value: nextValue, totalMatches, matchesByRule };
 }
 
 function sanitizePageUrl(pageUrl) {
-  if (!pageUrl) {
-    return pageUrl;
-  }
-
-  try {
-    const url = new URL(pageUrl);
-    url.search = '';
-    url.hash = '';
-    return url.toString();
-  } catch (error) {
-    return pageUrl.split('?')[0].split('#')[0];
-  }
+    if (!pageUrl) return pageUrl;
+    try {
+        const url = new URL(pageUrl);
+        url.search = "";
+        url.hash = "";
+        return url.toString();
+    } catch (error) {
+        return pageUrl.split("?")[0].split("#")[0];
+    }
 }
 
 function normalizePrivacySettings(privacySettings) {
-  return {
-    require_manual_review:
-      privacySettings.require_manual_review ?? DEFAULT_PRIVACY_SETTINGS.require_manual_review,
-    enable_redaction:
-      privacySettings.enable_redaction ?? DEFAULT_PRIVACY_SETTINGS.enable_redaction,
-    unlink_shared_ids:
-      privacySettings.unlink_shared_ids ?? DEFAULT_PRIVACY_SETTINGS.unlink_shared_ids,
-    regex_rules_text:
-      privacySettings.regex_rules_text || DEFAULT_PRIVACY_SETTINGS.regex_rules_text,
-  };
+    return {
+        require_manual_review: privacySettings.require_manual_review ?? DEFAULT_PRIVACY_SETTINGS.require_manual_review,
+        enable_redaction: privacySettings.enable_redaction ?? DEFAULT_PRIVACY_SETTINGS.enable_redaction,
+        unlink_shared_ids: privacySettings.unlink_shared_ids ?? DEFAULT_PRIVACY_SETTINGS.unlink_shared_ids,
+        regex_rules_text: privacySettings.regex_rules_text || DEFAULT_PRIVACY_SETTINGS.regex_rules_text,
+    };
 }
 
 async function getPrivacySettings() {
-  const stored = await getFromStorage('privacy_settings');
-  return normalizePrivacySettings(stored || {});
+    const stored = await getFromStorage("privacy_settings");
+    return normalizePrivacySettings(stored || {});
 }
 
 function deepClone(value) {
-  return JSON.parse(JSON.stringify(value));
+    return JSON.parse(JSON.stringify(value));
 }
 
 function changeIcon(activate) {
-  let iconPath;
-  if (activate) {
-    iconPath = {
-      '16': 'assets/icons/icon16.png',
-      '32': 'assets/icons/icon32.png',
-      '48': 'assets/icons/icon48.png',
-      '128': 'assets/icons/icon128.png'
-    };
-  } else {
-    iconPath = {
-      '16': 'assets/icons/icon16_non_active.png',
-      '32': 'assets/icons/icon32_non_active.png',
-      '48': 'assets/icons/icon48.png',
-      '128': 'assets/icons/icon128.png'
-    };
-  }
-
-  chrome.action.setIcon({ path: iconPath });
+    let iconPath;
+    if (activate) {
+        iconPath = {
+            "16": "assets/icons/icon16.png",
+            "32": "assets/icons/icon32.png",
+            "48": "assets/icons/icon48.png",
+            "128": "assets/icons/icon128.png"
+        };
+    } else {
+        iconPath = {
+            "16": "assets/icons/icon16_non_active.png",
+            "32": "assets/icons/icon32_non_active.png",
+            "48": "assets/icons/icon48.png",
+            "128": "assets/icons/icon128.png"
+        };
+    }
+    chrome.action.setIcon({ path: iconPath });
 }
 
 function handleIconStatus(tabId) {
-  chrome.tabs.get(tabId, (tab) => {
-    if (chrome.runtime.lastError) {
-      return;
-    }
-
-    chrome.tabs.sendMessage(tab.id, { type: 'gradio?' }, (response) => {
-      if (chrome.runtime.lastError) {
-        changeIcon(false);
-      } else if (response && response.gradio) {
-        changeIcon(true);
-      } else {
-        changeIcon(false);
-      }
+    chrome.tabs.get(tabId, (tab) => {
+        if (chrome.runtime.lastError) {
+            return;
+        }
+        chrome.tabs.sendMessage(tab.id, { type: "gradio?" }, function(response) {
+            if (chrome.runtime.lastError) {
+                changeIcon(false);
+            } else if (response && response.gradio) {
+                changeIcon(true);
+            } else {
+                changeIcon(false);
+            }
+        });
     });
-  });
 }
 
 function updateSharingStatus(tabId) {
-  chrome.tabs.get(tabId, (tab) => {
-    if (chrome.runtime.lastError) {
-      return;
-    }
-
-    chrome.tabs.sendMessage(tab.id, { type: 'update?' }, () => {
-      if (chrome.runtime.lastError) {
-        return;
-      }
+    chrome.tabs.get(tabId, (tab) => {
+        if (chrome.runtime.lastError) {
+            return;
+        }
+        chrome.tabs.sendMessage(tab.id, { type: "update?" }, function() {});
     });
-  });
 }
 
 function isTimestampOlderThanXHours(timestamp, currentTimeToCheck, numHours) {
-  if (!timestamp) {
-    return false;
-  }
-  const HoursInMillis = 60 * 60 * 1000 * numHours;
-  return (new Date(currentTimeToCheck) - new Date(timestamp)) > HoursInMillis;
+    const HoursInMillis = 60 * 60 * 1000 * numHours;
+    return (new Date(currentTimeToCheck) - new Date(timestamp)) > HoursInMillis;
 }
 
-function toPromise(callback) {
-  return new Promise((resolve, reject) => {
-    try {
-      callback(resolve, reject);
-    } catch (err) {
-      reject(err);
-    }
-  });
+const toPromise = (callback) => {
+    return new Promise((resolve, reject) => {
+        try {
+            callback(resolve, reject);
+        }
+        catch (err) {
+            reject(err);
+        }
+    });
 }
 
 function saveToStorage(field, value) {
-  return toPromise((resolve, reject) => {
-    const dataToSave = {};
-    dataToSave[field] = value;
-
-    chrome.storage.local.set(dataToSave, () => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-      } else {
-        resolve(value);
-      }
+    return toPromise((resolve, reject) => {
+        const dataToSave = {};
+        dataToSave[field] = value;
+        chrome.storage.local.set(dataToSave, function () {
+            if (chrome.runtime.lastError) {
+                reject(chrome.runtime.lastError);
+            } else {
+                resolve(value);
+            }
+        });
     });
-  });
 }
 
 function getFromStorage(field) {
-  return toPromise((resolve, reject) => {
-    chrome.storage.local.get([field], (result) => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-        return;
-      }
-
-      if (Object.prototype.hasOwnProperty.call(result, field)) {
-        resolve(result[field]);
-      } else {
-        resolve(null);
-      }
+    return toPromise((resolve, reject) => {
+        chrome.storage.local.get([field], (result) => {
+            if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+            else if (Object.prototype.hasOwnProperty.call(result, field)) resolve(result[field]);
+            else resolve(null);
+        });
     });
-  });
-}
-
-function uuidv4() {
-  return '00-0-4-1-000'.replace(/[^-]/g,
-      s => ((Math.random() + ~~s) * 0x10000 >> s).toString(16).padStart(4, '0')
-  );
 }
 
 function safeIncrementMessagesCounter(messageCount) {
-  return enqueueStorageUpdate(async () => {
-    const messagesCounterFromStorage = await getFromStorage('messages_counter_from_storage');
+    return enqueueStorageUpdate(async () => {
+        const messages_counter_from_storage = await getFromStorage("messages_counter_from_storage");
+        let updated_messages_counter = messages_counter_from_storage ? messages_counter_from_storage + messageCount : messageCount;
+        await saveToStorage("messages_counter_from_storage", updated_messages_counter);
+        return updated_messages_counter;
+    });
+}
 
-    let updatedMessagesCounter = 0;
-    if (messagesCounterFromStorage) {
-      updatedMessagesCounter = messagesCounterFromStorage + messageCount;
-    } else {
-      updatedMessagesCounter = messageCount;
-    }
-
-    await saveToStorage('messages_counter_from_storage', updatedMessagesCounter);
-    return updatedMessagesCounter;
-  });
+function uuidv4() {
+    return '00-0-4-1-000'.replace(/[^-]/g,
+        s => ((Math.random() + ~~s) * 0x10000 >> s).toString(16).padStart(4, '0')
+    );
 }

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,369 +1,606 @@
-// background.js
 const API_URL = "https://share-lm-4e25a5769ac0.herokuapp.com/api/endpoint";
 
-let isUpdatingCounter = false;
+const DEFAULT_PRIVACY_SETTINGS = {
+  require_manual_review: true,
+  enable_redaction: true,
+  unlink_shared_ids: true,
+  regex_rules_text: [
+    String.raw`\b(?:\d{1,3}\.){3}\d{1,3}\b => [REDACTED_IP]`,
+    String.raw`[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,} => [REDACTED_EMAIL]`,
+    String.raw`\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b => [REDACTED_MAC]`,
+    String.raw`\b[0-9A-Fa-f]{8}-(?:[0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}\b => [REDACTED_UUID]`,
+    String.raw`(?:(?:[A-Za-z]:)?(?:\\|/)[^\s"']+) => [REDACTED_PATH]`,
+  ].join('\n'),
+};
 
-// ==== Simple Request Queue ====
 const requestQueue = [];
 let isProcessing = false;
 
-function enqueueStorageUpdate(updateFunction) {
-    return new Promise((resolve, reject) => {
-        requestQueue.push({ updateFunction, resolve, reject });
-        processQueue();
-    });
-}
-
-function processQueue() {
-    if (isProcessing || requestQueue.length === 0) return;
-
-    isProcessing = true;
-    const { updateFunction, resolve, reject } = requestQueue.shift();
-
-    updateFunction()
-        .then((result) => {
-            resolve(result);
-            isProcessing = false;
-            processQueue();
-        })
-        .catch((error) => {
-            reject(error);
-            isProcessing = false;
-            processQueue();
-        });
-}
-
-
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    // Ensure the tab has finished loading
-    if (changeInfo.status === 'complete') {
-        handleIconStatus(tabId);
-        updateSharingStatus(tabId);
-    }
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status === 'complete') {
+    handleIconStatus(tabId);
+    updateSharingStatus(tabId);
+  }
 });
 
 chrome.tabs.onActivated.addListener((activeInfo) => {
-    handleIconStatus(activeInfo.tabId);
-    updateSharingStatus(activeInfo.tabId);
+  handleIconStatus(activeInfo.tabId);
+  updateSharingStatus(activeInfo.tabId);
 });
 
-// Set an interval to run the function once in 5 min (in milliseconds)
 const MinInMillis = 60 * 1000;
-setInterval(removeInvalidAndPostToDb, 5 * MinInMillis);
+setInterval(() => {
+  removeInvalidAndPostToDb(true).catch((error) => {
+    console.error('Scheduled publish failed', error);
+  });
+}, 5 * MinInMillis);
 
+handleRuntimeMessages();
 
-// Define a function to change the extension icon
-function changeIcon(activate) {
-    let iconPath;
-    if (activate) {
-        iconPath = {
-            "16": "assets/icons/icon16.png",
-            "32": "assets/icons/icon32.png",
-            "48": "assets/icons/icon48.png",
-            "128": "assets/icons/icon128.png"
+function enqueueStorageUpdate(updateFunction) {
+  return new Promise((resolve, reject) => {
+    requestQueue.push({ updateFunction, resolve, reject });
+    processQueue();
+  });
+}
+
+function processQueue() {
+  if (isProcessing || requestQueue.length === 0) {
+    return;
+  }
+
+  isProcessing = true;
+  const { updateFunction, resolve, reject } = requestQueue.shift();
+
+  Promise.resolve()
+    .then(updateFunction)
+    .then((result) => {
+      resolve(result);
+      isProcessing = false;
+      processQueue();
+    })
+    .catch((error) => {
+      reject(error);
+      isProcessing = false;
+      processQueue();
+    });
+}
+
+function handleRuntimeMessages() {
+  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.type === 'update_local_db_ids') {
+      enqueueStorageUpdate(async () => {
+        if (!request.id_to_add || !request.conversation) {
+          return { ok: false, error: 'missing conversation payload' };
+        }
+
+        let localDbIds = (await getFromStorage('local_db_ids')) || [];
+        const existingConversation = await getFromStorage(request.id_to_add);
+        const storedConversation = await buildStoredConversation(
+          request.id_to_add,
+          request.conversation,
+          existingConversation
+        );
+
+        if (!localDbIds.includes(request.id_to_add)) {
+          localDbIds = [...localDbIds, request.id_to_add];
+          await saveToStorage('local_db_ids', localDbIds);
+        }
+
+        await saveToStorage(request.id_to_add, storedConversation);
+
+        return {
+          ok: true,
+          request_type: 'add',
+          conversation_id: request.id_to_add,
+          conversation: storedConversation,
         };
-    } else {
-        iconPath = {
-            "16": "assets/icons/icon16_non_active.png",
-            "32": "assets/icons/icon32_non_active.png",
-            "48": "assets/icons/icon48.png",
-            "128": "assets/icons/icon128.png"
-        };
+      })
+        .then(sendResponse)
+        .catch((error) => {
+          console.error('Failed to update local archive', error);
+          sendResponse({ ok: false, error: String(error) });
+        });
+      return true;
     }
 
-    chrome.action.setIcon({ path: iconPath });
+    if (request.type === 'publish') {
+      removeInvalidAndPostToDb(false)
+        .then(sendResponse)
+        .catch((error) => {
+          console.error('Manual publish failed', error);
+          sendResponse({ ok: false, error: String(error) });
+        });
+      return true;
+    }
+
+    if (request.type === 'update_conversation_privacy') {
+      enqueueStorageUpdate(async () => {
+        const conversation = await getFromStorage(request.conversation_id);
+        if (!conversation) {
+          return { ok: false, error: 'conversation not found' };
+        }
+
+        if (conversation.published_at) {
+          conversation.publish_state = 'shared';
+        } else if (request.publish_state) {
+          conversation.publish_state = request.publish_state;
+        }
+
+        conversation.updated_at = new Date().toISOString();
+        await saveToStorage(request.conversation_id, conversation);
+
+        return { ok: true, conversation };
+      })
+        .then(sendResponse)
+        .catch((error) => {
+          console.error('Failed to update conversation privacy', error);
+          sendResponse({ ok: false, error: String(error) });
+        });
+      return true;
+    }
+
+    if (request.type === 'get_privacy_settings') {
+      getPrivacySettings()
+        .then((privacySettings) => sendResponse({ ok: true, privacy_settings: privacySettings }))
+        .catch((error) => sendResponse({ ok: false, error: String(error) }));
+      return true;
+    }
+
+    if (request.type === 'save_privacy_settings') {
+      const normalized = normalizePrivacySettings(request.privacy_settings || {});
+      saveToStorage('privacy_settings', normalized)
+        .then(() => sendResponse({ ok: true, privacy_settings: normalized }))
+        .catch((error) => sendResponse({ ok: false, error: String(error) }));
+      return true;
+    }
+
+    return false;
+  });
+}
+
+async function buildStoredConversation(conversationId, incomingConversation, existingConversation) {
+  const privacySettings = await getPrivacySettings();
+  const shouldShareState = await getFromStorage('shouldShare');
+  const shouldShare = shouldShareState === null ? true : Boolean(shouldShareState.shouldShare);
+  const now = new Date().toISOString();
+
+  let publishState;
+  if (existingConversation && existingConversation.published_at) {
+    publishState = 'shared';
+  } else if (existingConversation && existingConversation.publish_state) {
+    publishState = existingConversation.publish_state;
+  } else if (!shouldShare) {
+    publishState = 'blocked';
+  } else {
+    publishState = privacySettings.require_manual_review ? 'needs_review' : 'approved';
+  }
+
+  return {
+    ...incomingConversation,
+    created_at: existingConversation?.created_at || incomingConversation.timestamp || now,
+    updated_at: now,
+    publish_state: publishState,
+    published_at: existingConversation?.published_at || null,
+    shared_user_id: existingConversation?.shared_user_id || null,
+  };
+}
+
+async function removeInvalidAndPostToDb(checkInterval = true) {
+  const currentTime = new Date();
+  const localDbIds = (await getFromStorage('local_db_ids')) || [];
+  let publishedCount = 0;
+  let skippedCount = 0;
+
+  for (const conversationId of [...localDbIds]) {
+    const conversation = await getFromStorage(conversationId);
+
+    if (!conversation) {
+      const nextIds = localDbIds.filter((item) => item !== conversationId);
+      await saveToStorage('local_db_ids', nextIds);
+      continue;
+    }
+
+    if (conversation.published_at) {
+      skippedCount += 1;
+      continue;
+    }
+
+    const publishState = conversation.publish_state || 'approved';
+    if (publishState !== 'approved') {
+      skippedCount += 1;
+      continue;
+    }
+
+    if (checkInterval && !isTimestampOlderThanXHours(conversation.timestamp, currentTime, 24)) {
+      skippedCount += 1;
+      continue;
+    }
+
+    const success = await sendConversation(conversationId, conversation);
+    if (success) {
+      conversation.published_at = new Date().toISOString();
+      conversation.publish_state = 'shared';
+      conversation.updated_at = conversation.published_at;
+      await saveToStorage(conversationId, conversation);
+      publishedCount += 1;
+    }
+  }
+
+  return {
+    ok: true,
+    published_count: publishedCount,
+    skipped_count: skippedCount,
+    total_local_conversations: localDbIds.length,
+  };
+}
+
+async function sendConversation(conversationId, conversation) {
+  try {
+    const payload = await buildPublishPayload(conversationId, conversation);
+    const response = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Network response was not ok (${response.status})`);
+    }
+
+    await response.json();
+    const messageCount = Array.isArray(payload.user_msgs) ? payload.user_msgs.length : 0;
+    await safeIncrementMessagesCounter(messageCount);
+    return true;
+  } catch (error) {
+    console.error('Error sending conversation:', error);
+    return false;
+  }
+}
+
+async function buildPublishPayload(conversationId, conversation) {
+  const privacySettings = await getPrivacySettings();
+  let userId = await getFromStorage('user_id');
+  if (userId === null) {
+    userId = uuidv4();
+    await saveToStorage('user_id', userId);
+  }
+
+  const userMetadata = (await getFromStorage('user_metadata')) || {};
+  const conversationMetadata = {};
+
+  if ('ratings' in conversation) {
+    conversationMetadata.message_ratings = conversation.ratings;
+  }
+
+  const rate = await getFromStorage(`rate_${conversationId}`);
+  if (rate !== null) {
+    conversationMetadata.rate = rate;
+  }
+
+  const sanitizedConversation = privacySettings.enable_redaction
+    ? applyRedactionsToConversation(conversation, privacySettings.regex_rules_text)
+    : { conversation: deepClone(conversation), summary: { total_matches: 0, matches_by_rule: [] } };
+
+  if (privacySettings.enable_redaction) {
+    conversationMetadata.redaction_summary = sanitizedConversation.summary;
+  }
+
+  let sharedUserId = userId;
+  if (privacySettings.unlink_shared_ids) {
+    sharedUserId = conversation.shared_user_id || uuidv4();
+    if (sharedUserId !== conversation.shared_user_id) {
+      conversation.shared_user_id = sharedUserId;
+      await saveToStorage(conversationId, conversation);
+    }
+    conversationMetadata.shared_user_id_mode = 'per_conversation';
+  } else {
+    conversationMetadata.shared_user_id_mode = 'stable';
+  }
+
+  return {
+    conversation_id: conversationId,
+    bot_msgs: sanitizedConversation.conversation.bot_msgs || [],
+    user_msgs: sanitizedConversation.conversation.user_msgs || [],
+    page_url: sanitizePageUrl(sanitizedConversation.conversation.page_url),
+    user_id: sharedUserId,
+    user_metadata: {
+      ...userMetadata,
+      sharelm_privacy_mode: describePrivacyMode(privacySettings),
+    },
+    timestamp: sanitizedConversation.conversation.timestamp,
+    conversation_metadata: conversationMetadata,
+  };
+}
+
+function describePrivacyMode(privacySettings) {
+  if (
+    privacySettings.require_manual_review ||
+    privacySettings.enable_redaction ||
+    privacySettings.unlink_shared_ids
+  ) {
+    return 'advanced';
+  }
+  return 'standard';
+}
+
+function applyRedactionsToConversation(conversation, rulesText) {
+  const clonedConversation = deepClone(conversation);
+  const rules = parseRedactionRules(rulesText);
+  const summary = {
+    total_matches: 0,
+    matches_by_rule: [],
+  };
+
+  const applyToValue = (value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    const result = redactString(value, rules);
+    summary.total_matches += result.totalMatches;
+    result.matchesByRule.forEach((item) => {
+      const existing = summary.matches_by_rule.find((entry) => entry.name === item.name);
+      if (existing) {
+        existing.count += item.count;
+      } else {
+        summary.matches_by_rule.push({ name: item.name, count: item.count });
+      }
+    });
+    return result.value;
+  };
+
+  clonedConversation.user_msgs = (clonedConversation.user_msgs || []).map(applyToValue);
+  clonedConversation.bot_msgs = (clonedConversation.bot_msgs || []).map(applyToValue);
+  clonedConversation.page_url = applyToValue(clonedConversation.page_url || '');
+
+  if (Array.isArray(clonedConversation.canvas_snapshots)) {
+    clonedConversation.canvas_snapshots = clonedConversation.canvas_snapshots.map((snapshot) => ({
+      ...snapshot,
+      data: snapshot.data
+        ? {
+            ...snapshot.data,
+            textContent: applyToValue(snapshot.data.textContent || ''),
+            htmlContent: applyToValue(snapshot.data.htmlContent || ''),
+            displayTitle: applyToValue(snapshot.data.displayTitle || ''),
+          }
+        : snapshot.data,
+    }));
+  }
+
+  if (Array.isArray(clonedConversation.conversation_timeline)) {
+    clonedConversation.conversation_timeline = clonedConversation.conversation_timeline.map((item) => {
+      if (typeof item.content === 'string') {
+        return { ...item, content: applyToValue(item.content) };
+      }
+
+      if (item.content && typeof item.content === 'object') {
+        return {
+          ...item,
+          content: {
+            ...item.content,
+            title: applyToValue(item.content.title || ''),
+            textContent: applyToValue(item.content.textContent || ''),
+            trigger: item.content.trigger,
+          },
+        };
+      }
+
+      return item;
+    });
+  }
+
+  return { conversation: clonedConversation, summary };
+}
+
+function parseRedactionRules(rulesText) {
+  const lines = (rulesText || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+
+  return lines
+    .map((line, index) => {
+      const separatorIndex = line.indexOf('=>');
+      if (separatorIndex === -1) {
+        return null;
+      }
+
+      const patternText = line.slice(0, separatorIndex).trim();
+      const replacement = line.slice(separatorIndex + 2).trim();
+
+      try {
+        return {
+          name: `rule_${index + 1}`,
+          regex: new RegExp(patternText, 'g'),
+          replacement,
+        };
+      } catch (error) {
+        console.warn('Skipping invalid redaction rule', line, error);
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function redactString(value, rules) {
+  let nextValue = value;
+  let totalMatches = 0;
+  const matchesByRule = [];
+
+  for (const rule of rules) {
+    const matches = nextValue.match(rule.regex);
+    if (!matches || matches.length === 0) {
+      continue;
+    }
+
+    totalMatches += matches.length;
+    matchesByRule.push({ name: rule.name, count: matches.length });
+    nextValue = nextValue.replace(rule.regex, rule.replacement);
+  }
+
+  return { value: nextValue, totalMatches, matchesByRule };
+}
+
+function sanitizePageUrl(pageUrl) {
+  if (!pageUrl) {
+    return pageUrl;
+  }
+
+  try {
+    const url = new URL(pageUrl);
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch (error) {
+    return pageUrl.split('?')[0].split('#')[0];
+  }
+}
+
+function normalizePrivacySettings(privacySettings) {
+  return {
+    require_manual_review:
+      privacySettings.require_manual_review ?? DEFAULT_PRIVACY_SETTINGS.require_manual_review,
+    enable_redaction:
+      privacySettings.enable_redaction ?? DEFAULT_PRIVACY_SETTINGS.enable_redaction,
+    unlink_shared_ids:
+      privacySettings.unlink_shared_ids ?? DEFAULT_PRIVACY_SETTINGS.unlink_shared_ids,
+    regex_rules_text:
+      privacySettings.regex_rules_text || DEFAULT_PRIVACY_SETTINGS.regex_rules_text,
+  };
+}
+
+async function getPrivacySettings() {
+  const stored = await getFromStorage('privacy_settings');
+  return normalizePrivacySettings(stored || {});
+}
+
+function deepClone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function changeIcon(activate) {
+  let iconPath;
+  if (activate) {
+    iconPath = {
+      '16': 'assets/icons/icon16.png',
+      '32': 'assets/icons/icon32.png',
+      '48': 'assets/icons/icon48.png',
+      '128': 'assets/icons/icon128.png'
+    };
+  } else {
+    iconPath = {
+      '16': 'assets/icons/icon16_non_active.png',
+      '32': 'assets/icons/icon32_non_active.png',
+      '48': 'assets/icons/icon48.png',
+      '128': 'assets/icons/icon128.png'
+    };
+  }
+
+  chrome.action.setIcon({ path: iconPath });
 }
 
 function handleIconStatus(tabId) {
-    chrome.tabs.get(tabId, (tab) => {
-        if (chrome.runtime.lastError) {
-            // console.error(chrome.runtime.lastError);
-            return;
-        }
+  chrome.tabs.get(tabId, (tab) => {
+    if (chrome.runtime.lastError) {
+      return;
+    }
 
-        // Send a message to the content script
-        chrome.tabs.sendMessage(tab.id, { type: "gradio?" }, function(response) {
-            if (chrome.runtime.lastError) {
-                changeIcon(false);
-            } else if (response && response.gradio) {
-                changeIcon(true);
-            } else {
-                changeIcon(false);
-            }
-        });
+    chrome.tabs.sendMessage(tab.id, { type: 'gradio?' }, (response) => {
+      if (chrome.runtime.lastError) {
+        changeIcon(false);
+      } else if (response && response.gradio) {
+        changeIcon(true);
+      } else {
+        changeIcon(false);
+      }
     });
+  });
 }
 
 function updateSharingStatus(tabId) {
-    chrome.tabs.get(tabId, (tab) => {
-        if (chrome.runtime.lastError) {
-            // console.error(chrome.runtime.lastError);
-            return;
-        }
-
-        // Send a message to the content script
-        chrome.tabs.sendMessage(tab.id, { type: "update?" }, function(response) {
-            if (chrome.runtime.lastError) {
-                // console.log("error sending message update? to content script");
-            }
-        });
-    });}
-
-function handleLocalDbIds() {
-    // load local_db_ids from storage
-
-    // handle local_db_ids updates requests
-    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-        if (request.type === "update_local_db_ids") {
-            let local_db_ids = [];
-            getFromStorage("local_db_ids").then((local_db_ids_from_storage) => {
-                if (local_db_ids_from_storage !== null) {
-                    local_db_ids = local_db_ids_from_storage;
-                    console.log("local_db_ids loaded from storage", local_db_ids);
-                }
-                // add new conversation request
-                if (request.id_to_add) {
-                    console.log("add new conversation request", request);
-                    const index = local_db_ids.indexOf(request.id_to_add);
-                    if (index < 0) { // only add to array if not already there
-                        local_db_ids.push(request.id_to_add);
-                        saveToStorage("local_db_ids", local_db_ids);
-                    }
-                    if (request.conversation) {
-                        saveToStorage(request.id_to_add, request.conversation);
-                    }
-                    sendResponse({ local_db_ids: local_db_ids, request_type: "add" , conversion_id: request.id_to_add});
-                // }
-                // // remove conversation request
-                // else if (request.id_to_remove) {
-                //     console.log("remove conversation request");
-                //     // find the index of the conversation and remove it from the array
-                //     const index = local_db_ids.indexOf(request.id_to_remove);
-                //     if (index > -1) { // only splice array when item is found
-                //         local_db_ids.splice(index, 1); // 2nd parameter means remove one item only
-                //         saveToStorage("local_db_ids", local_db_ids);
-                //     }
-                //     // remove the conversation from the database
-                //     chrome.storage.local.remove([request.id_to_remove], () => {
-                //         if (chrome.runtime.lastError) {
-                //             console.error("Error removing conversation from storage", chrome.runtime.lastError);
-                //         } else {
-                //             console.log("conversation removed from storage");
-                //         }
-                //     });
-                //     sendResponse({ local_db_ids: local_db_ids , request_type: "remove", conversion_id: request.id_to_remove});
-                } else {
-                    console.log("error: update request with no id to add/remove", request);
-                }
-            });
-        } else if (request.type === "publish") {
-            removeInvalidAndPostToDb(false);
-            console.log("got publish request");
-        } 
-
-    });
-}
-
-// Function to send the conversation to the server
-function sendConversation(conversation_id, data_short) {
-    console.log("sending conversation to server...")
-
-    let conversation_metadata = {}
-    if ("ratings" in data_short) {
-        conversation_metadata["message_ratings"] = data_short.ratings;
+  chrome.tabs.get(tabId, (tab) => {
+    if (chrome.runtime.lastError) {
+      return;
     }
-    getFromStorage("rate_" + conversation_id).then((rate) => {
-        if (rate !== null) {
-            conversation_metadata["rate"] = rate;
-        }
 
-        getFromStorage("user_id").then((user_id_from_storage) => {
-            console.log("user_id_from_storage:", user_id_from_storage);
-            if (user_id_from_storage === null) {
-                user_id_from_storage = uuidv4();
-                saveToStorage("user_id", user_id_from_storage);
-            }
-            let user_id = user_id_from_storage;
-
-            getFromStorage("user_metadata").then((user_metadata_from_storage) => {
-                console.log("user_metadata_from_storage:", user_metadata_from_storage);
-                let user_metadata = user_metadata_from_storage ?? {};
-
-                // Send data in the integrated format (Canvas content merged into bot_msgs)
-                const data = {
-                    conversation_id: conversation_id,
-                    bot_msgs: data_short.bot_msgs, // Contains integrated Canvas content
-                    user_msgs: data_short.user_msgs,
-                    page_url: data_short.page_url,
-                    user_id: user_id,
-                    user_metadata: user_metadata,
-                    timestamp: data_short.timestamp,
-                    conversation_metadata: conversation_metadata,
-                };
-                
-                console.log("data:", data);
-                fetch(API_URL, {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify(data),
-                })
-                    .then((response) => {
-                        if (!response.ok) {
-                            throw new Error("Network response was not ok");
-                        }
-                        console.log("response", response);
-                        return response.json();
-                    })
-                    .then((data) => {
-                        console.log("data", data);
-                        // conversation_id = data.conversation_id;
-                    })
-                    .catch((error) => {
-                        console.error("Error:", error);
-                    });
-            });
-
-            // getFromStorage("messages_counter_from_storage").then((messages_counter_from_storage) => {
-            //     let updated_messages_counter = 0;
-            //     if (messages_counter_from_storage) {
-            //         updated_messages_counter = messages_counter_from_storage + data_short.user_msgs.length
-            //     } else { // first message ever!
-            //         updated_messages_counter = data_short.user_msgs.length;
-            //     }
-            //     saveToStorage("messages_counter_from_storage", updated_messages_counter);
-            // });
-            safeIncrementMessagesCounter(data_short).then((newVal) => {
-                console.log("New counter:", newVal);
-            });
-
-        });
+    chrome.tabs.sendMessage(tab.id, { type: 'update?' }, () => {
+      if (chrome.runtime.lastError) {
+        return;
+      }
     });
+  });
 }
 
-function removeInvalidAndPostToDb(checkInterval = true) {
-    console.log("removeInvalidAndPostToDb()");
-    const currentTime = new Date();
-
-    // Iterate over conversation IDs. Get local_db_ids from storage
-    getFromStorage("local_db_ids").then((local_db_from_storage) => {
-        local_db_ids = local_db_from_storage ?? local_db_ids;
-        console.log("iterating over local_db_ids", local_db_ids);
-        local_db_ids.forEach(async (conversationId) => {
-            // Retrieve the conversation object from storage
-            getFromStorage(conversationId).then((conversation) => {
-                if (conversation === null) {
-                    console.log("conversation is null");
-                    console.log("removing conversation from local_db_ids");
-                    chrome.storage.local.remove([conversationId], () => {
-                        if (chrome.runtime.lastError) {
-                            console.error("Error removing conversation from storage", chrome.runtime.lastError);
-                        } else {
-                            console.log("conversation removed from storage");
-                        }
-                    });
-                    const index = local_db_ids.indexOf(conversationId);
-                    if (index > -1) { // only splice array when item is found
-                        local_db_ids.splice(index, 1); // 2nd parameter means remove one item only
-                        saveToStorage("local_db_ids", local_db_ids);
-                    }
-                } else {
-                    console.log("conversation:", conversation);
-                    if (!checkInterval || isTimestampOlderThanXHours(conversation.timestamp, currentTime, 24)) {
-                        // ask the background script to remove the conversation
-                        console.log("removing conversation");
-                        // chrome.runtime.sendMessage({type: "update_local_db_ids", id_to_remove: conversationId}, function (response) {
-                        //     console.log(response);
-                        // });
-                        chrome.storage.local.remove([conversationId], () => {
-                            if (chrome.runtime.lastError) {
-                                console.error("Error removing conversation from storage", chrome.runtime.lastError);
-                            } else {
-                                console.log("conversation removed from storage");
-                            }
-                        });
-                        const index = local_db_ids.indexOf(conversationId);
-                        if (index > -1) { // only splice array when item is found
-                            local_db_ids.splice(index, 1); // 2nd parameter means remove one item only
-                            saveToStorage("local_db_ids", local_db_ids);
-                        }
-                        // Post to the DB
-                        console.log("posting conversation to DB");
-                        sendConversation(conversationId, conversation);
-                    }
-                }
-            });
-        });
-    });
-}
-
-// Function to check if a timestamp is older than one hour
 function isTimestampOlderThanXHours(timestamp, currentTimeToCheck, numHours) {
-    const HoursInMillis = 60 * 60 * 1000 * numHours;
-    return (new Date(currentTimeToCheck) - new Date(timestamp)) > HoursInMillis;
+  if (!timestamp) {
+    return false;
+  }
+  const HoursInMillis = 60 * 60 * 1000 * numHours;
+  return (new Date(currentTimeToCheck) - new Date(timestamp)) > HoursInMillis;
 }
 
-
-const toPromise = (callback) => {
-    const promise = new Promise((resolve, reject) => {
-        try {
-            callback(resolve, reject);
-        }
-        catch (err) {
-            reject(err);
-        }
-    });
-    return promise;
+function toPromise(callback) {
+  return new Promise((resolve, reject) => {
+    try {
+      callback(resolve, reject);
+    } catch (err) {
+      reject(err);
+    }
+  });
 }
 
 function saveToStorage(field, value) {
+  return toPromise((resolve, reject) => {
     const dataToSave = {};
-    dataToSave[field] = value; // Construct the object with the dynamic key.
+    dataToSave[field] = value;
 
-    chrome.storage.local.set(dataToSave, function () {
-        if (chrome.runtime.lastError) {
-            console.error(chrome.runtime.lastError);
-        } else {
-            console.log(field, " saved");
-        }
+    chrome.storage.local.set(dataToSave, () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+      } else {
+        resolve(value);
+      }
     });
+  });
 }
-
 
 function getFromStorage(field) {
-    const promise = toPromise((resolve, reject) => {
-        chrome.storage.local.get([field], (result) => {
-            if (chrome.runtime.lastError)
-                reject(chrome.runtime.lastError);
+  return toPromise((resolve, reject) => {
+    chrome.storage.local.get([field], (result) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
 
-            if (result[field]) {
-                resolve(result[field]);
-                console.log("got ", field, " from storage")
-            } else {
-                resolve(null);
-            }
-        });
+      if (Object.prototype.hasOwnProperty.call(result, field)) {
+        resolve(result[field]);
+      } else {
+        resolve(null);
+      }
     });
-    return promise;
+  });
 }
 
-function safeIncrementMessagesCounter(data_short) {
-    return enqueueStorageUpdate(async () => {
-        const messages_counter_from_storage = await getFromStorage("messages_counter_from_storage");
-
-        let updated_messages_counter = 0;
-        if (messages_counter_from_storage) {
-            updated_messages_counter = messages_counter_from_storage + data_short.user_msgs.length;
-        } else {
-            updated_messages_counter = data_short.user_msgs.length;
-        }
-
-        await saveToStorage("messages_counter_from_storage", updated_messages_counter);
-
-        return updated_messages_counter;
-    });
+function uuidv4() {
+  return '00-0-4-1-000'.replace(/[^-]/g,
+      s => ((Math.random() + ~~s) * 0x10000 >> s).toString(16).padStart(4, '0')
+  );
 }
 
+function safeIncrementMessagesCounter(messageCount) {
+  return enqueueStorageUpdate(async () => {
+    const messagesCounterFromStorage = await getFromStorage('messages_counter_from_storage');
 
-handleLocalDbIds();
+    let updatedMessagesCounter = 0;
+    if (messagesCounterFromStorage) {
+      updatedMessagesCounter = messagesCounterFromStorage + messageCount;
+    } else {
+      updatedMessagesCounter = messageCount;
+    }
+
+    await saveToStorage('messages_counter_from_storage', updatedMessagesCounter);
+    return updatedMessagesCounter;
+  });
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -247,6 +247,131 @@
       margin: 5px 0;
     }
 
+    .privacy-card {
+      margin-top: 14px;
+      background-color: white;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+      padding: 12px;
+    }
+
+    .privacy-card h3 {
+      margin-top: 0;
+    }
+
+    .privacy-grid {
+      display: grid;
+      gap: 8px;
+    }
+
+    .privacy-grid label {
+      display: flex;
+      gap: 8px;
+      align-items: flex-start;
+      font-size: 0.85rem;
+    }
+
+    #regex-rules-text {
+      width: 100%;
+      min-height: 120px;
+      resize: vertical;
+      font-family: monospace;
+      font-size: 0.75rem;
+      box-sizing: border-box;
+    }
+
+    #privacy-save-status {
+      margin-top: 8px;
+      font-size: 0.8rem;
+      text-align: left;
+    }
+
+    .status-success {
+      color: #14532d;
+    }
+
+    .status-error {
+      color: #991b1b;
+    }
+
+    .status-badge {
+      display: inline-block;
+      padding: 4px 8px;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: bold;
+    }
+
+    .status-needs_review {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .status-approved {
+      background: #dbeafe;
+      color: #1d4ed8;
+    }
+
+    .status-blocked {
+      background: #e5e7eb;
+      color: #111827;
+    }
+
+    .status-shared {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .icon-button {
+      display: block;
+      margin: 4px auto;
+      border: none;
+      background: none;
+      cursor: pointer;
+      font-size: 1rem;
+    }
+
+    .button-active-green {
+      background: rgba(34, 197, 94, 0.2);
+      border-radius: 8px;
+    }
+
+    .button-active-red {
+      background: rgba(239, 68, 68, 0.2);
+      border-radius: 8px;
+    }
+
+    .mini-action-button {
+      display: block;
+      width: 100%;
+      margin-bottom: 6px;
+      font-size: 0.75rem;
+      border-radius: 0.4rem;
+      border: 1px solid #cbd5e1;
+      background: white;
+      cursor: pointer;
+      padding: 4px 6px;
+    }
+
+    .mini-action-button:hover {
+      background: #eff6ff;
+    }
+
+    .danger-action:hover {
+      background: #fee2e2;
+    }
+
+    .conversation-meta {
+      margin-top: 6px;
+      font-size: 0.72rem;
+      color: #475569;
+    }
+
+    .read-more-link {
+      display: block;
+      margin-top: 6px;
+    }
 
   </style>
 </head>
@@ -317,20 +442,35 @@
     <thead>
     <tr>
       <th>Conversations</th>
+      <th>Status</th>
       <th>Rate</th>
-      <th>Remove?</th> <!-- Add a new column for actions -->
+      <th>Actions</th>
     </tr>
     </thead>
     <tbody></tbody>
   </table>
   <div class="button-container">
-    <p>Your data is *YOURS*. Click here to download your locally stored conversations (the ones in the table) as a CSV file</p>
-    <button id="downloadButton" class="disable-sharing-button" type="submit" name="download">Download</button>
+    <p>Your data is yours. Download the full local archive, including review state and Canvas captures, as JSON.</p>
+    <button id="downloadButton" class="disable-sharing-button" type="button" name="download">Download JSON Backup</button>
   </div>
   <div class="button-container">
-    <p>We are publishing the conversations to the DB with a delay. You can publish now to empty the local storage</p>
-    <button id="publishButton" class="disable-sharing-button" type="submit" name="publish">Publish Now</button>
+    <p>Only conversations marked Approved are published. Shared conversations stay in the local archive for later review.</p>
+    <button id="publishButton" class="disable-sharing-button" type="button" name="publish">Publish Approved</button>
   </div>
+</div>
+
+<div id="privacy-controls" class="privacy-card">
+  <h3>Privacy &amp; Review Controls</h3>
+  <p>Use advanced mode to keep conversations local first, redact obvious identifiers, and publish only after review.</p>
+  <form id="privacy-settings-form" class="privacy-grid">
+    <label><input id="require-manual-review" type="checkbox"> Require manual approval before publishing</label>
+    <label><input id="enable-redaction" type="checkbox"> Apply regex redaction rules before upload</label>
+    <label><input id="unlink-shared-ids" type="checkbox"> Use per-conversation public IDs instead of one stable public ID</label>
+    <label for="regex-rules-text">Regex redaction rules</label>
+    <textarea id="regex-rules-text" class="custom-input" spellcheck="false"></textarea>
+    <button id="privacy-save-button" class="disable-sharing-button" type="submit">Save Privacy Settings</button>
+    <div id="privacy-save-status" class="hidden"></div>
+  </form>
 </div>
 
 <!--<div id="message"></div>-->


### PR DESCRIPTION
Copy of the PR I made against my own repo for some visibility: https://github.com/Erotemic/share-lm/pull/1

At this point the purpose of the PR is more to document the issues I want to address rather than say that this is the correct implementation of those issues. I have not reviewed the code at all. It is entirely vibe coded, but the description of what I want it to be doing is correct. 

AI description:

## Title

Add privacy review controls, local archive retention, and regex redaction before publish

## Summary

This PR is a first pass at making ShareLM friendlier for users who want a more privacy-conscious workflow without giving up local collection.

The current flow is optimized for low friction: capture conversations locally, allow a short review window, and then publish. That works well for users who want the easiest path to contributing, but it leaves a gap for users who want more control over what gets released, how identifiers are handled, and whether sensitive details should be transformed before anything leaves local storage.

This patch starts closing that gap by introducing review-oriented publishing controls, basic regex-based redaction, and unlinkable shared identifiers, while preserving the existing lightweight collection flow.

## Problems this is trying to address

There are a few related privacy and UX issues:

* Some conversations are almost shareable, but still need lightweight cleanup before release.
* Users may want to keep a full local archive of their chats even when they do not want those chats published immediately.
* Stable identifiers across shared conversations can create linking risk, where one identifiable conversation can make others easier to de-anonymize.
* “Not shared” currently reads as a failure state more than a valid privacy choice.
* There is not a strong separation between “captured locally” and “approved for publishing.”

## What this PR attempts to do

This PR introduces a more explicit privacy/review layer between local capture and remote publish.

At a high level, it:

* keeps conversations in local storage after publication instead of treating publish as destructive
* adds a publish state / review gate so only approved conversations are uploaded
* introduces privacy settings for:

  * manual review before publish
  * regex-based text redaction
  * per-conversation shared IDs instead of one stable shared ID
* applies redaction before upload rather than relying only on downstream processing
* strips query params / fragments from page URLs before sending them
* lays the groundwork for a better popup review flow where conversations can be approved, blocked, or kept private

## Implementation notes

The current patch is intentionally scoped as a first step, not a full privacy workflow.

Main ideas in this implementation:

* **Local archive retention**
  Published conversations remain stored locally, with `published_at` / `publish_state` metadata, instead of being deleted on upload.

* **Review state**
  Conversations now move through an explicit local state such as `needs_review`, `approved`, `blocked`, or `shared`. Upload only happens for `approved` conversations.

* **Regex redaction**
  A configurable ruleset is stored locally and applied to text fields before upload. This is meant to cover straightforward cases like IPs, emails, UUIDs, MAC addresses, and file paths.

* **Unlinkable sharing identifiers**
  When enabled, each conversation gets its own shared user ID for upload, instead of reusing one stable public-facing identifier across all releases.

* **Safer upload payloads**
  Upload uses the transformed/redacted copy, not the raw local copy, and page URLs are sanitized before sending.

## What this does not fully solve yet

This is not meant to be the final privacy UX.

Still missing or only partially addressed:

* a polished popup UI for reviewing and approving conversations
* redaction preview / diff view
* delayed release scheduling
* richer metadata inspection
* model-assisted local sensitivity tagging
* more advanced anonymization beyond regex rules

## Why this structure

The goal here is to preserve the existing “easy to contribute” behavior while making it possible to support a more advanced, opt-in privacy mode.

Instead of redesigning the whole extension at once, this PR focuses on introducing the core data model and upload-boundary changes first:

* retain local data
* separate capture from publish
* redact before upload
* reduce cross-conversation linkability

That should make later UX improvements much easier to build on top of a safer backend flow.

## Follow-up ideas

Likely next steps after this PR:

* add explicit approve / block controls in the popup
* improve status labeling and iconography for private vs shared
* add redaction rule editing and preview in the popup
* optionally support delayed publish / staged release
* export raw local archive vs approved/redacted archive separately
